### PR TITLE
chequeo de la palabra "bot"

### DIFF
--- a/bot/bot_subcmd.go
+++ b/bot/bot_subcmd.go
@@ -15,9 +15,13 @@ func SubCmd(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	// bot word mention
-	if strings.Contains(m.Content, "bot") {
-		_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbot)`)
-		return
+	words := strings.Fields(m.Content)
+
+	for _, word := range words {
+		if word == "bot" {
+			_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbottttt)`)
+			return
+		}
 	}
 
 	// stop if not use subcommand prefix

--- a/bot/bot_subcmd.go
+++ b/bot/bot_subcmd.go
@@ -19,7 +19,7 @@ func SubCmd(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	for _, word := range words {
 		if word == "bot" {
-			_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbottttt)`)
+			_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbot)`)
 			return
 		}
 	}

--- a/bot/bot_subcmd.go
+++ b/bot/bot_subcmd.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"database/sql"
 	"strings"
+	"regexp"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/gophers-latam/challenges/global"
@@ -15,13 +16,9 @@ func SubCmd(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	// bot word mention
-	words := strings.Fields(m.Content)
-
-	for _, word := range words {
-		if word == "bot" {
-			_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbot)`)
-			return
-		}
+	if matched, err := regexp.MatchString("\\bbot\\b", m.Content); err == nil && matched {
+		_, _ = s.ChannelMessageSend(m.ChannelID, `envia: .go (para usar el gopherbot)`)
+		return
 	}
 
 	// stop if not use subcommand prefix


### PR DESCRIPTION
En esta PR, lo que se busca, es evitar que el bot aparezca cuando no es llamado.
Algunos casos de prueba fueron cuando se escribian palabras como "ro**bot**", "**bot**ella`,  "**bot**on", "**bot**onera" y el bot aparecia.

Evidencia:
![image](https://github.com/gophers-latam/challenges/assets/73196303/b30e91eb-cfaf-4ab1-8558-2bd0e1d3ccd5)
