### PR TITLE
nuevo subcomando "facts"

### DIFF
--- a/bot/bot_subcmd.go
+++ b/bot/bot_subcmd.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"database/sql"
 	"strings"
+	"math/rand"
 	"regexp"
 
 	"github.com/bwmarrin/discordgo"
@@ -30,6 +31,41 @@ func SubCmd(s *discordgo.Session, m *discordgo.MessageCreate) {
 	// go to hello subcommand
 	if len(args) == 1 && args[0] == ".go" {
 		msgHello(s, m)
+		return
+	}
+
+	if args[1] == "facts" {
+		facts := []string{
+			"1. Los miembros de Gophers LATAM pueden escribir una api Go en microsoft paint y compilarla en excel escrita en Ruby",
+			"2. Cuando el compilador encuentra un error en el código de Gophers LATAM, el compilador se disculpa",
+			"3. Gophers LATAM puede dividir por cero, pero el compilador asustado intenta multiplicar por el infinito",
+			"4. Gophers LATAM puede arrojar una excepción mas lejos que nadie y en menor tiempo",
+			"5. Cuando Gophers LATAM presiona [ctr-alt-del] es el resto mundo el que se reinicia",
+			"6. Gophers LATAM no necesita recolector de basura. Solo mira a los objetos fijamente y los objetos se destruyen a si mismos muertos de miedo",
+			"7. Gophers LATAM no necesita compilar su código Go. Le basta escribir en Javascript y se traduce el mismo a binario",
+			"8. Los miembros de Gophers LATAM no tienen tecla [CONTROL] en su teclado, ellos siempre están en control",
+			"9. Gophers LATAM puede detectar el siguiente número en una secuencia aleatoria",
+			"10. Gophers LATAM puede ejecutar un loop infinito en 3 segundos",
+			"11. Gophers LATAM no puede producir un Null Pointer Exception, si Gophers LATAM apunta a Null, un objeto se materializa instantaneamente",
+			"12. Gophers LATAM puede hacer control-z con lápiz y papel",
+			"14. Gophers LATAM te hace updates a la base de datos con el buscaminas",
+			"15. Los arrays de Gophers LATAM son de tamaño infinito porque Gophers LATAM no tiene límites.",
+			"16. Gophers LATAM terminó World of Warcraft",
+			"17. Solo hay 10 clases de personas, los que son parte de Gophers LATAM y los que no",
+		}
+
+		selection := rand.Intn(len(facts))
+
+		author := discordgo.MessageEmbedAuthor{
+			Name: "El Programador Pobre",
+		}			
+
+		embed := discordgo.MessageEmbed{
+			Title: facts[selection],
+			Author: &author,
+		}
+
+		s.ChannelMessageSendEmbed(m.ChannelID, &embed)
 		return
 	}
 

--- a/views/index.html
+++ b/views/index.html
@@ -66,6 +66,7 @@
         <li><b>.go help</b> - ver sub-comandos generales disponibles</li>
         <li><b>.go awesome</b> - recursos comunidad</li>
         <li><b>.go challenge</b> - pedir desafio para practicar</li>
+        <li><b>.go facts</b> - chistes internos de la comunidad, ejecutalo y te sorprenderas</li>
         <li>...</li>
       </ul>
       <br>


### PR DESCRIPTION
Hola! 
En esta PR se crea un nuevo subcomando: _**.go facts**_

Este subcomando itera sobre una lista que se envio con varios [chistes internos](https://discord.com/channels/764989185077542942/782450500922376242/1225967061197394003) de la comunidad.

La idea es simple, pero más adelante, se podría guardar la lista con cada chiste y su autor en una nueva tabla de base de datos y llamarlos desde ahí, para que no quede harcodeado.

- Además, se agrega en el index.html el nuevo comando para que los usuarios sepan como utilizarlo.

### Cambios en la BD
Cada vez que se agrega un nuevo comando, este deberá de estar en la tabla de comandos de la BD.
Además, se actualizó el texto del _**.go help**_ para que también se muestre el nuevo comando

_**Se envían los cambios de la BD por privado a @zeroidentidad**_

### Pruebas
Se adjuntan los testeos:

![image](https://github.com/gophers-latam/challenges/assets/73196303/c6546985-8d84-4b2f-8de3-6b54d8406e33)